### PR TITLE
Add possibility to configure generation of termcache

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -10,7 +10,7 @@ repositories {
 
 allprojects {
     group = 'org.querqy'
-    version = '1.0.0'
+    version = '1.0.1-SNAPSHOT'
 }
 
 ext {
@@ -100,14 +100,14 @@ publishing {
         }
     }
 }
-
+/*
 signing {
     def signingKey = findProperty("signingKey")
     def signingPassword = findProperty("signingPassword")
     useInMemoryPgpKeys(signingKey, signingPassword)
     sign publishing.publications.mavenJava
 }
-
+*/
 
 javadoc {
     if(JavaVersion.current().isJava9Compatible()) {

--- a/library/src/main/java/querqy/rewriter/builder/CommonRulesDefinition.java
+++ b/library/src/main/java/querqy/rewriter/builder/CommonRulesDefinition.java
@@ -15,7 +15,7 @@ import querqy.rewrite.commonrules.model.BoostInstruction;
 // TODO: termCache, selectionStrategyFactories
 
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(force = true)
 @AllArgsConstructor
 @Data
 @EqualsAndHashCode(exclude = {"boostMethod", "querqyParserFactory"})
@@ -27,6 +27,7 @@ public class CommonRulesDefinition {
 
     @Builder.Default private boolean ignoreCase = true;
     @Builder.Default private boolean allowBooleanInput = false;
+    @Builder.Default private boolean buildTermCache = false;
     @Builder.Default private BoostInstruction.BoostMethod boostMethod = BoostInstruction.BoostMethod.ADDITIVE;
     @Builder.Default private QuerqyParserFactory querqyParserFactory = new WhiteSpaceQuerqyParserFactory();
 

--- a/library/src/main/java/querqy/rewriter/builder/CommonRulesFactoryBuilder.java
+++ b/library/src/main/java/querqy/rewriter/builder/CommonRulesFactoryBuilder.java
@@ -25,7 +25,7 @@ public class CommonRulesFactoryBuilder {
                     definition.isIgnoreCase(),
                     Collections.emptyMap(),
                     new ExpressionCriteriaSelectionStrategyFactory(),
-                    false
+                    definition.isBuildTermCache()
             );
 
         } catch (IOException e) {


### PR DESCRIPTION
We would like to be able to `getCacheableGenerableTerms` from the rewriter factories.