### PR TITLE
fix: missing character encoding

### DIFF
--- a/library/src/main/java/querqy/rewriter/builder/ReplaceRulesFactoryBuilder.java
+++ b/library/src/main/java/querqy/rewriter/builder/ReplaceRulesFactoryBuilder.java
@@ -18,7 +18,7 @@ public class ReplaceRulesFactoryBuilder {
         try (
                 final ByteArrayInputStream rulesInput = new ByteArrayInputStream(
                         definition.getRules().getBytes(StandardCharsets.UTF_8));
-                final InputStreamReader rulesReader = new InputStreamReader(rulesInput)
+                final InputStreamReader rulesReader = new InputStreamReader(rulesInput, StandardCharsets.UTF_8)
         ){
             return new ReplaceRewriterFactory(
                     definition.getRewriterId(),


### PR DESCRIPTION
Without it, some systems (at least temurin <17 under containers) would assume the system default "something not UTF-8".