### PR TITLE
Make Decorations available #13

### DIFF
--- a/integration-elasticsearch/build.gradle
+++ b/integration-elasticsearch/build.gradle
@@ -20,15 +20,16 @@ dependencies {
 
     testImplementation "co.elastic.clients:elasticsearch-java:${elasticsearchVersion}"
     testImplementation "com.fasterxml.jackson.core:jackson-databind:2.12.3"
-    testImplementation 'org.testcontainers:testcontainers:1.17.6'
-    testImplementation 'org.testcontainers:elasticsearch:1.17.6'
+    testImplementation 'org.testcontainers:testcontainers:2.0.3'
+    testImplementation 'org.testcontainers:testcontainers-elasticsearch:2.0.3'
+    testImplementation "junit:junit:4.13.2"
 
     testImplementation project(":library")
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
-    testCompileOnly 'org.projectlombok:lombok:1.18.24'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+    testCompileOnly 'org.projectlombok:lombok:1.18.38'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
 }
 
 test {
@@ -39,7 +40,7 @@ test {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = 11
+    sourceCompatibility = 21
 }
 
 javadoc {

--- a/integration-solr/build.gradle
+++ b/integration-solr/build.gradle
@@ -21,16 +21,16 @@ dependencies {
     compileOnly "org.apache.lucene:lucene-core:${luceneSolrVersion}"
     compileOnly "org.apache.solr:solr-core:${luceneSolrVersion}"
 
-    testImplementation "org.querqy:querqy-solr:5.6.lucene980.0"
+    testImplementation "org.querqy:querqy-solr:5.9.lucene980.0"
     testImplementation "org.apache.solr:solr-test-framework:${luceneSolrVersion}"
     testImplementation "org.assertj:assertj-core:3.22.0"
-    testImplementation "junit:junit:4.11"
+    testImplementation "junit:junit:4.13.2"
     testImplementation project(":library")
 
-    compileOnly 'org.projectlombok:lombok:1.18.24'
-    annotationProcessor 'org.projectlombok:lombok:1.18.24'
-    testCompileOnly 'org.projectlombok:lombok:1.18.24'
-    testAnnotationProcessor 'org.projectlombok:lombok:1.18.24'
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+    testCompileOnly 'org.projectlombok:lombok:1.18.38'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
 
 }
 
@@ -42,7 +42,7 @@ test {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = 11
+    sourceCompatibility = 21
 }
 
 publishing {

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -51,7 +51,7 @@ test {
 java {
     withJavadocJar()
     withSourcesJar()
-    sourceCompatibility = 11
+    sourceCompatibility = 21
 }
 
 publishing {

--- a/library/src/main/java/querqy/domain/RewrittenQuerqyQuery.java
+++ b/library/src/main/java/querqy/domain/RewrittenQuerqyQuery.java
@@ -4,11 +4,17 @@ import lombok.Builder;
 import lombok.Getter;
 import querqy.model.ExpandedQuery;
 
+import java.util.Collections;
 import java.util.Map;
+import java.util.Set;
 
 @Builder
 @Getter
 public class RewrittenQuerqyQuery {
     private final ExpandedQuery query;
     private final Map<String, Object> rewriteLogging;
+    @Builder.Default
+    private Set<Object> decorations = Collections.emptySet();
+    @Builder.Default
+    private Map<String, Object> namedDecorations = Collections.emptyMap();
 }

--- a/library/src/main/java/querqy/domain/RewrittenQuery.java
+++ b/library/src/main/java/querqy/domain/RewrittenQuery.java
@@ -2,12 +2,26 @@ package querqy.domain;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NonNull;
+
+import java.util.Map;
+import java.util.Set;
 
 @Builder
 @Getter
 public class RewrittenQuery<T> {
 
     private final T convertedQuery;
+
+    @NonNull
     private final RewrittenQuerqyQuery rewrittenQuerqyQuery;
+    
+    public Set<Object> getDecorations() {
+        return rewrittenQuerqyQuery.getDecorations();
+    }
+
+    public Map<String, Object> getNamedDecorations() {
+        return rewrittenQuerqyQuery.getNamedDecorations();
+    }
 
 }

--- a/library/src/main/java/querqy/rewriter/QueryRewritingExecutor.java
+++ b/library/src/main/java/querqy/rewriter/QueryRewritingExecutor.java
@@ -15,12 +15,14 @@ import querqy.parser.QuerqyParser;
 import querqy.rewrite.RewriteChain;
 import querqy.rewrite.RewriteChainOutput;
 import querqy.rewrite.commonrules.QuerqyParserFactory;
+import querqy.rewrite.commonrules.model.DecorateInstruction;
 import querqy.rewrite.logging.RewriteChainLog;
 import querqy.rewriter.builder.ExpandedQueryParser;
 
 import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
 
 @Builder
 public class QueryRewritingExecutor {
@@ -46,10 +48,27 @@ public class QueryRewritingExecutor {
 
         final RewriteChainOutput rewriteChainOutput = rewriteChain.rewrite(parsedQuery, requestAdapter);
 
-        return RewrittenQuerqyQuery.builder()
-                .query(rewriteChainOutput.getExpandedQuery())
-                .rewriteLogging(extractRewriteLog(rewriteChainOutput))
-                .build();
+        final RewrittenQuerqyQuery.RewrittenQuerqyQueryBuilder builder = RewrittenQuerqyQuery.builder();
+        builder.query(rewriteChainOutput.getExpandedQuery())
+                .rewriteLogging(extractRewriteLog(rewriteChainOutput));
+
+        final Map<String, Object> context = requestAdapter.getContext();
+
+        if (context != null) {
+
+            @SuppressWarnings("unchecked")
+            final Set<Object> decorations = (Set<Object>) context.get(DecorateInstruction.DECORATION_CONTEXT_KEY);
+
+            builder.decorations(decorations);
+
+            @SuppressWarnings("unchecked")
+            final Map<String, Object> namedDecorations =
+                    (Map<String, Object>) context.get(DecorateInstruction.DECORATION_CONTEXT_MAP_KEY);
+            builder.namedDecorations(namedDecorations);
+        }
+
+
+        return builder.build();
     }
 
     private LocalSearchEngineRequestAdapter createLocalSearchEngineRequestAdapter(final RewriteChain rewriteChain) {

--- a/library/src/test/java/querqy/converter/elasticsearch/CommonRulesRewritingTest.java
+++ b/library/src/test/java/querqy/converter/elasticsearch/CommonRulesRewritingTest.java
@@ -1,0 +1,78 @@
+package querqy.converter.elasticsearch;
+
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import org.junit.Test;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.elasticsearch.javaclient.ESJavaClientConverterConfig;
+import querqy.converter.elasticsearch.javaclient.ESJavaClientConverterFactory;
+import querqy.domain.RewrittenQuery;
+import querqy.rewriter.builder.CommonRulesDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class CommonRulesRewritingTest {
+
+    @Test
+    public void testDecorationsWithoutKeys() {
+
+        final ConverterFactory<Query> converterFactory = ESJavaClientConverterFactory.of(
+                ESJavaClientConverterConfig.builder()
+                        .rawQueryInputType(ESJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("""
+                                        iphone =>\s
+                                         SYNONYM: apple smartphone
+                                         FILTER: apple
+                                         DECORATE: REDIRECT https://example.com/apple
+                                        
+                                        4 inch =>\s
+                                         DECORATE: TEASER <small_smartphones>""")
+                                .build()
+                )
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("name", 40.0f)
+                .field("type", 20.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+        final RewrittenQuery<Query> query = queryRewriting.rewriteQuery("iphone 4 inch ");
+
+        // test decorations
+        assertThat(query.getDecorations())
+                .hasSize(2)
+                .contains("REDIRECT https://example.com/apple")
+                .contains("TEASER <small_smartphones>")
+
+        ;
+
+        // test that main query is still there
+        final Query convertedQuery = query.getConvertedQuery();
+        assertTrue(convertedQuery._get() instanceof BoolQuery);
+        final BoolQuery boolQuery = (BoolQuery) convertedQuery._get();
+        assertThat(boolQuery.filter()).isNotEmpty(); // we just test whether the filter was created
+
+    }
+
+
+}

--- a/library/src/test/java/querqy/rewriter/QueryRewritingExecutorTest.java
+++ b/library/src/test/java/querqy/rewriter/QueryRewritingExecutorTest.java
@@ -205,4 +205,44 @@ public class QueryRewritingExecutorTest {
 
         assertThat(rewrittenQuery.getRewriteLogging()).isNotEmpty();
     }
+
+    @Test
+    public void testThat_DecorationsAreAvailableFromASingleCommonRulesRewriter() {
+        final QuerqyConfig rewritingConfig = QuerqyConfig.builder()
+                .rewriterFactory(
+                        RewriterSupport.createRewriterFactory(
+                                "common",
+                                "id", "1",
+                                "rules", """
+                                        apple smartphone =>
+                                          SYNONYM: iphone
+                                          DECORATE: REDIRECT https://example.com/apple
+                                        """
+                        )
+                )
+                .build();
+
+        final RewrittenQuerqyQuery rewrittenQuery = QueryRewritingExecutor.builder()
+                .querqyConfig(rewritingConfig)
+                .build()
+                .rewriteQuery("apple smartphone");
+
+        assertThat(rewrittenQuery.getDecorations()).hasSize(1).contains("REDIRECT https://example.com/apple");
+
+        final ExpandedQueryBuilder expanded = expanded(rewrittenQuery.getQuery());
+
+        // are gthe other rules stuill being applied?
+        assertThat(expanded.getUserQuery()).isEqualTo(
+                bq(
+                        dmq(
+                                term("apple"),
+                                term("iphone", true)
+                        ),
+                        dmq(
+                                term("smartphone"),
+                                term("iphone", true)
+                        )
+                )
+        );
+    }
 }


### PR DESCRIPTION
Decorations are now available after rewriting via

```
RewrittenQuery.getDecorations()
```

See https://docs.querqy.org/querqy/rewriters/common-rules.html#decorate-rules for how to configure them on CommonRulesRewriter
