### PR TITLE
fix: upgrade integration-solr to Solr 9.5 / Lucene 9.8 and fix mm per…

### DIFF
--- a/integration-solr/build.gradle
+++ b/integration-solr/build.gradle
@@ -9,7 +9,8 @@ repositories {
 }
 
 ext {
-    luceneSolrVersion = '8.11.2'
+    luceneVersion = '9.8.0'
+    solrVersion = '9.5.0'
 }
 
 allprojects {
@@ -18,11 +19,11 @@ allprojects {
 }
 
 dependencies {
-    compileOnly "org.apache.lucene:lucene-core:${luceneSolrVersion}"
-    compileOnly "org.apache.solr:solr-core:${luceneSolrVersion}"
+    compileOnly "org.apache.lucene:lucene-core:${luceneVersion}"
+    compileOnly "org.apache.solr:solr-core:${solrVersion}"
 
     testImplementation "org.querqy:querqy-solr:5.9.lucene980.0"
-    testImplementation "org.apache.solr:solr-test-framework:${luceneSolrVersion}"
+    testImplementation "org.apache.solr:solr-test-framework:${solrVersion}"
     testImplementation "org.assertj:assertj-core:3.22.0"
     testImplementation "junit:junit:4.13.2"
     testImplementation project(":library")

--- a/integration-solr/src/main/java/solr/qparser/BoolQParserWrapper.java
+++ b/integration-solr/src/main/java/solr/qparser/BoolQParserWrapper.java
@@ -39,7 +39,8 @@ public class BoolQParserWrapper extends QParser {
     }
 
     private String parseMinShouldMatch() {
-        return DisMaxQParser.parseMinShouldMatch(super.req.getSchema(), getLocalParams());
+        return DisMaxQParser.parseMinShouldMatch(
+                super.req.getSchema(), SolrParams.wrapDefaults(getLocalParams(), params));
     }
 
     private Query potentiallyWrapByBoostQuery(final Query query) {

--- a/integration-solr/src/main/java/solr/qparser/BoolQParserWrapperPlugin.java
+++ b/integration-solr/src/main/java/solr/qparser/BoolQParserWrapperPlugin.java
@@ -13,7 +13,12 @@ public class BoolQParserWrapperPlugin extends QParserPlugin {
         final BoolQParserPlugin boolQParserPlugin = new BoolQParserPlugin();
         final SolrParams localSolrParams = localParams == null ? new ModifiableSolrParams() : localParams;
 
-        final QParser boolQParser = boolQParserPlugin.createParser(qstr, localSolrParams, params, req);
+        // Solr 9's BoolQParserPlugin calls getInt("mm") on localParams, which breaks for percentage
+        // values like "100%". Strip mm here; BoolQParserWrapper applies it via setMinShouldMatch.
+        final ModifiableSolrParams localParamsWithoutMm = new ModifiableSolrParams(localSolrParams);
+        localParamsWithoutMm.remove("mm");
+
+        final QParser boolQParser = boolQParserPlugin.createParser(qstr, localParamsWithoutMm, params, req);
 
         return new BoolQParserWrapper(boolQParser, qstr, localParams, params, req);
     }


### PR DESCRIPTION
…centage parsing

Upgrades Solr and Lucene dependencies from 8.11.2 to 9.5.0/9.8.0 to match querqy-solr:5.9.lucene980.0, which requires Lucene 9.x on the classpath.

Solr 9's BoolQParserPlugin now calls getInt("mm") on localParams, which breaks for DisMax-style percentage values like "100%". Fix by stripping mm from the localParams passed to BoolQParserPlugin and letting BoolQParserWrapper apply it via SolrPluginUtils.setMinShouldMatch as before. Also widen the mm lookup in BoolQParserWrapper to fall back to global params so the value is picked up regardless of where it is set.