### PR TITLE
Add OpenSearch support #7

### DIFF
--- a/integration-opensearch/build.gradle
+++ b/integration-opensearch/build.gradle
@@ -1,0 +1,48 @@
+plugins {
+    id 'java'
+}
+
+repositories {
+    mavenCentral()
+}
+
+ext {
+    opensearchVersion = '3.8.0'
+}
+
+allprojects {
+    group = 'org.querqy'
+    version = '0.1.0'
+}
+
+dependencies {
+    testImplementation "org.assertj:assertj-core:3.22.0"
+
+    testImplementation "org.opensearch.client:opensearch-java:${opensearchVersion}"
+    testImplementation 'org.testcontainers:testcontainers:2.0.3'
+    testImplementation 'org.opensearch:opensearch-testcontainers:4.1.0'
+    testImplementation "junit:junit:4.13.2"
+
+    testImplementation project(":library")
+
+    compileOnly 'org.projectlombok:lombok:1.18.38'
+    annotationProcessor 'org.projectlombok:lombok:1.18.38'
+    testCompileOnly 'org.projectlombok:lombok:1.18.38'
+    testAnnotationProcessor 'org.projectlombok:lombok:1.18.38'
+}
+
+test {
+    useJUnit()
+}
+
+java {
+    withJavadocJar()
+    withSourcesJar()
+    sourceCompatibility = 21
+}
+
+javadoc {
+    if(JavaVersion.current().isJava9Compatible()) {
+        options.addBooleanOption('html5', true)
+    }
+}

--- a/integration-opensearch/src/test/java/opensearch/AbstractOpenSearchTest.java
+++ b/integration-opensearch/src/test/java/opensearch/AbstractOpenSearchTest.java
@@ -1,0 +1,145 @@
+package opensearch;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.apache.hc.core5.http.HttpHost;
+import org.junit.After;
+import org.junit.Before;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch._types.Refresh;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.transport.OpenSearchTransport;
+import org.opensearch.client.transport.httpclient5.ApacheHttpClient5TransportBuilder;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import querqy.QuerqyConfig;
+import querqy.QueryRewriting;
+import querqy.rewriter.builder.CommonRulesDefinition;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public abstract class AbstractOpenSearchTest {
+
+    protected OpenSearchClient client;
+
+    protected abstract OpenSearchContainer<?> getOpenSearchContainer();
+    protected abstract List<Product> getProducts();
+    protected abstract String getIndexName();
+
+    @Before
+    public void setup() {
+        getOpenSearchContainer().start();
+
+        createClient();
+        indexProducts(getProducts());
+    }
+
+    private void createClient() {
+        final HttpHost host = new HttpHost("http",
+                getOpenSearchContainer().getHost(), getOpenSearchContainer().getMappedPort(9200));
+
+        final OpenSearchTransport transport = ApacheHttpClient5TransportBuilder.builder(host)
+                .setMapper(new JacksonJsonpMapper())
+                .build();
+
+        client = new OpenSearchClient(transport);
+    }
+
+    @After
+    public void shutDown() {
+        getOpenSearchContainer().stop();
+    }
+
+
+    protected Map<String, Object> idAndScoreMap(final String id, final Double score) {
+        return Map.of("id", id,"_score", score);
+    }
+
+    protected List<Map<String, Object>> toIdAndScoreMaps(final List<Product> products) {
+        return products.stream()
+                .map(product -> idAndScoreMap(product.getId(), product.get_score()))
+                .collect(Collectors.toList());
+    }
+
+    protected List<String> toIdList(final List<Product> products) {
+        return products.stream()
+                .map(Product::getId)
+                .collect(Collectors.toList());
+    }
+
+    protected List<Product> search(final Query query) {
+        try {
+            final SearchResponse<Product> response = client.search(s -> s
+                            .index(getIndexName())
+                            .query(query),
+                    Product.class);
+
+            return matches(response);
+
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @SuppressWarnings("ConstantConditions")
+    protected List<Product> matches(final SearchResponse<Product> response) {
+        return response.hits().hits().stream()
+                .map(hit -> {
+                    final Product product = hit.source();
+                    product.set_score(hit.score());
+                    return product;
+                })
+                .collect(Collectors.toList());
+    }
+
+    protected QuerqyConfig querqyConfig(final String rules) {
+        return QuerqyConfig.builder()
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules(rules)
+                                .build()
+                )
+                .build();
+    }
+
+    private void indexProducts(final List<Product> products) {
+        products.forEach(this::indexProduct);
+    }
+
+    private void indexProduct(final Product product) {
+        try {
+            client.index(i -> i
+                    .index(getIndexName())
+                    .id(product.getId())
+                    .document(product)
+                    .refresh(Refresh.True)
+            );
+        } catch (final IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    protected Product product(final String id, final String name, final String type) {
+        Product product = new Product();
+        product.setId(id);
+        product.setName(name);
+        product.setType(type);
+
+        return product;
+    }
+
+    @Data
+    @NoArgsConstructor
+    public static class Product {
+        private String id;
+        private String name;
+        private String type;
+
+        private Double _score;
+    }
+}

--- a/integration-opensearch/src/test/java/opensearch/OpenSearch2Container.java
+++ b/integration-opensearch/src/test/java/opensearch/OpenSearch2Container.java
@@ -1,0 +1,23 @@
+package opensearch;
+
+import org.opensearch.testcontainers.OpenSearchContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class OpenSearch2Container {
+
+    private static OpenSearchContainer<?> openSearchContainer = null;
+
+    // TODO: maintain in build.gradle?
+    private static final String OPENSEARCH_DOCKER = "opensearchproject/opensearch:2.19.0";
+
+    private OpenSearch2Container() {
+    }
+
+    public static OpenSearchContainer<?> createOpenSearchContainer() {
+        if (openSearchContainer == null) {
+            openSearchContainer = new OpenSearchContainer<>(DockerImageName.parse(OPENSEARCH_DOCKER));
+        }
+
+        return openSearchContainer;
+    }
+}

--- a/integration-opensearch/src/test/java/opensearch/rewriting/ExpandedQueryTest.java
+++ b/integration-opensearch/src/test/java/opensearch/rewriting/ExpandedQueryTest.java
@@ -1,0 +1,256 @@
+package opensearch.rewriting;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import opensearch.AbstractOpenSearchTest;
+import opensearch.OpenSearch2Container;
+import org.junit.Test;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import querqy.BoostConfig;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.parser.FieldAwareWhiteSpaceQuerqyParser;
+import querqy.rewriter.builder.CommonRulesDefinition;
+import querqy.rewriter.builder.ReplaceRulesDefinition;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ExpandedQueryTest extends AbstractOpenSearchTest {
+
+    private static final String INDEX_NAME = "products";
+
+    private static final Map<String, String> RULES = Map.of(
+            "filter", "apple => \n  FILTER: smartphone",
+            "filter_with_field", "apple => \n  FILTER: type:smartphone",
+            "raw_filter", "apple => \n FILTER: * type:smartphone",
+            "raw_filter_json", "apple => \n FILTER: * {\"term\":{\"type\":\"smartphone\"}}",
+            "boost", "apple => \n UP(100): smartphone",
+            "boost_additive", "apple => \n UP(10): smartphone",
+            "boost_multiplicative", "apple => \n UP(1.5): smartphone",
+            "down_boost", "apple => \n DOWN(10): case"
+    );
+
+    private final List<Product> products = List.of(
+            product("1", "apple", "smartphone"),
+            product("2", "apple smartphone", "case"),
+            product("3", "apple", "case")
+    );
+
+    private final QueryConfig queryConfig = QueryConfig.builder()
+            .field("name", 40.0f)
+            .field("type", 20.0f)
+            .minimumShouldMatch("100%")
+            .tie(0.0f)
+            .build();
+
+
+    private final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.create();
+
+    private final ConverterFactory<Query> converterFactoryJson = OSJavaClientConverterFactory.of(
+            OSJavaClientConverterConfig.builder()
+                    .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                    .build()
+    );
+
+    @Test
+    public void testThat_allDocumentsAreReturned_forGivenMatchAllQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting();
+        final Query query = queryRewriting.rewriteQuery("*").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(products).hasSize(3);
+    }
+
+    @Test
+    public void testThat_documentsAreFiltered_forGivenFilterQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting("filter");
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdList(products)).containsExactlyInAnyOrder("1", "2");
+    }
+
+    @Test
+    public void testThat_rewriterChainIsApplied_forGivenCommonRulesAndReplaceRewriter() {
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+                .replaceRules(
+                        ReplaceRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("aple => apple")
+                                .build()
+                )
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id2")
+                                .rules(RULES.get("filter"))
+                                .querqyParserFactory(FieldAwareWhiteSpaceQuerqyParser::new)
+                                .build()
+                )
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = queryRewriting(querqyConfig, queryConfig);
+        final Query query = queryRewriting.rewriteQuery("aple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdList(products)).containsExactlyInAnyOrder("1", "2");
+    }
+
+    @Test
+    public void testThat_documentsAreFiltered_forGivenRawFilterJsonQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting("raw_filter_json", converterFactoryJson);
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdList(products)).containsExactlyInAnyOrder("1");
+    }
+
+    @Test
+    public void testThat_documentsAreFiltered_forGivenRawFilterQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting("raw_filter");
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdList(products)).containsExactlyInAnyOrder("1");
+    }
+
+    @Test
+    public void testThat_documentsAreFiltered_forGivenFieldFilterQuery() {
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules(RULES.get("filter_with_field"))
+                                .querqyParserFactory(FieldAwareWhiteSpaceQuerqyParser::new)
+                                .build()
+                )
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = queryRewriting(querqyConfig, queryConfig);
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdList(products)).containsExactlyInAnyOrder("1");
+    }
+
+    @Test
+    public void testThat_documentsAreBoosted_forGivenConstantScoreBoostQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting("boost");
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 140.0),
+                idAndScoreMap("2", 140.0),
+                idAndScoreMap("3", 40.0)
+        );
+    }
+
+    @Test
+    public void testThat_documentsAreBoosted_forGivenAdditiveBoostQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting(
+                "boost_additive",
+                queryConfig.toBuilder()
+                        .boostConfig(BoostConfig.builder()
+                                .queryScoreConfig(BoostConfig.QueryScoreConfig.ADD_TO_BOOST_PARAM)
+                                .build())
+                        .build()
+        );
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("2", 90.0),
+                idAndScoreMap("1", 70.0),
+                idAndScoreMap("3", 40.0)
+        );
+    }
+
+    @Test
+    public void testThat_documentsAreBoosted_forGivenMultiplicativeBoostQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting(
+                "boost_multiplicative",
+                queryConfig.toBuilder()
+                        .boostConfig(BoostConfig.builder()
+                                .queryScoreConfig(BoostConfig.QueryScoreConfig.MULTIPLY_WITH_BOOST_PARAM)
+                                .build())
+                        .build()
+        );
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("2", 100.0),
+                idAndScoreMap("1", 70.0),
+                idAndScoreMap("3", 40.0)
+        );
+    }
+
+    @Test
+    public void testThat_documentsArePunished_forGivenDownBoostQuery() {
+        final QueryRewriting<Query> queryRewriting = queryRewriting(
+                "down_boost",
+                queryConfig.toBuilder()
+                        .boostConfig(BoostConfig.builder()
+                                .queryScoreConfig(BoostConfig.QueryScoreConfig.ADD_TO_BOOST_PARAM)
+                                .build())
+                        .build()
+        );
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 50.0),
+                idAndScoreMap("2", 40.0),
+                idAndScoreMap("3", 40.0)
+        );
+    }
+
+    private QueryRewriting<Query> queryRewriting() {
+        return queryRewriting(QuerqyConfig.empty(), queryConfig);
+    }
+
+    private QueryRewriting<Query> queryRewriting(final String rulesKey) {
+        return queryRewriting(querqyConfig(RULES.get(rulesKey)), queryConfig);
+    }
+
+    private QueryRewriting<Query> queryRewriting(final String rulesKey, final ConverterFactory<Query> converterFactory) {
+        return queryRewriting(querqyConfig(RULES.get(rulesKey)), queryConfig, converterFactory);
+    }
+
+    private QueryRewriting<Query> queryRewriting(final String rulesKey, final QueryConfig queryConfig) {
+        return queryRewriting(querqyConfig(RULES.get(rulesKey)), queryConfig);
+    }
+
+    private QueryRewriting<Query> queryRewriting(final QuerqyConfig querqyConfig, final QueryConfig queryConfig) {
+        return queryRewriting(querqyConfig, queryConfig, converterFactory);
+    }
+
+    private QueryRewriting<Query> queryRewriting(final QuerqyConfig querqyConfig, final QueryConfig queryConfig, final ConverterFactory<Query> converterFactory) {
+        return QueryRewriting.<Query>builder()
+                .queryConfig(queryConfig)
+                .querqyConfig(querqyConfig)
+                .converterFactory(converterFactory)
+                .build();
+    }
+
+    @Override
+    protected List<AbstractOpenSearchTest.Product> getProducts() {
+        return products;
+    }
+
+    @Override
+    protected String getIndexName() {
+        return INDEX_NAME;
+    }
+
+    @Override
+    protected OpenSearchContainer<?> getOpenSearchContainer() {
+        return OpenSearch2Container.createOpenSearchContainer();
+    }
+}

--- a/integration-opensearch/src/test/java/opensearch/rewriting/QueryExpansionTest.java
+++ b/integration-opensearch/src/test/java/opensearch/rewriting/QueryExpansionTest.java
@@ -1,0 +1,136 @@
+package opensearch.rewriting;
+
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.TermQuery;
+import opensearch.AbstractOpenSearchTest;
+import opensearch.OpenSearch2Container;
+import org.junit.Test;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import querqy.QueryConfig;
+import querqy.QueryExpansionConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class QueryExpansionTest extends AbstractOpenSearchTest {
+
+    private static final String INDEX_NAME = "products";
+
+    private static final Map<String, String> RULES = Map.of(
+            "synonym_repeated", "apple smartphone => \n  SYNONYM: iphone",
+            "synonym_nested", "iphone => \n SYNONYM: apple smartphone",
+            "synonym_weighted", "iphone => \n SYNONYM(0.5): smartphone"
+    );
+
+    private final List<Product> products = List.of(
+            product("1", "apple", "smartphone"),
+            product("2", "huawei", "case"),
+            product("3", "samsung", "smartphone")
+    );
+
+    private final QueryConfig queryConfig = QueryConfig.builder()
+            .field("name", 40.0f)
+            .field("type", 20.0f)
+            .minimumShouldMatch("100%")
+            .tie(0.0f)
+            .build();
+
+
+    private final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.create();
+
+    @Test
+    public void testThat_resultsAreExpanded_forAlternativeMatchingStringQuery() {
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .queryConfig(queryConfig)
+                .queryExpansionConfig(
+                        QueryExpansionConfig.<Query>builder()
+                                .addAlternativeMatchingStringQuery("name:huawei", 50f)
+                        .build()
+                )
+                .converterFactory(converterFactory)
+                .build();
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+
+        System.out.println(toIdAndScoreMaps(products));
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 40.0),
+                idAndScoreMap("2", 50.0)
+        );
+    }
+
+    @Test
+    public void testThat_resultsAreExpanded_forBoostStringQuery() {
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .queryConfig(queryConfig)
+                .queryExpansionConfig(
+                        QueryExpansionConfig.<Query>builder()
+                                .addBoostUpStringQuery("name:apple", 50f)
+                        .build()
+                )
+                .converterFactory(converterFactory)
+                .build();
+        final Query query = queryRewriting.rewriteQuery("smartphone").getConvertedQuery();
+
+        final List<Product> products = search(query);
+
+        System.out.println(toIdAndScoreMaps(products));
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 70.0),
+                idAndScoreMap("3", 20.0)
+        );
+    }
+
+    @Test
+    public void testThat_resultsAreExpanded_forAlternativeMatchingQuery() {
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .queryConfig(queryConfig)
+                .queryExpansionConfig(
+                        QueryExpansionConfig.<Query>builder()
+                                .addAlternativeMatchingQuery(
+                                        new Query(
+                                                new TermQuery.Builder()
+                                                        .field("name")
+                                                        .value(FieldValue.of("huawei"))
+                                                        .build()
+                                        ),
+                                        50f)
+                        .build()
+                )
+                .converterFactory(converterFactory)
+                .build();
+        final Query query = queryRewriting.rewriteQuery("apple").getConvertedQuery();
+
+        final List<Product> products = search(query);
+
+        System.out.println(toIdAndScoreMaps(products));
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 40.0),
+                idAndScoreMap("2", 50.0)
+        );
+    }
+
+
+    @Override
+    protected List<Product> getProducts() {
+        return products;
+    }
+
+    @Override
+    protected String getIndexName() {
+        return INDEX_NAME;
+    }
+
+    @Override
+    protected OpenSearchContainer<?> getOpenSearchContainer() {
+        return OpenSearch2Container.createOpenSearchContainer();
+    }
+
+}

--- a/integration-opensearch/src/test/java/opensearch/rewriting/RewritingTest.java
+++ b/integration-opensearch/src/test/java/opensearch/rewriting/RewritingTest.java
@@ -1,0 +1,121 @@
+package opensearch.rewriting;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import opensearch.AbstractOpenSearchTest;
+import opensearch.OpenSearch2Container;
+import org.junit.Test;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RewritingTest extends AbstractOpenSearchTest {
+
+    private static final String INDEX_NAME = "products";
+
+    private static final Map<String, String> RULES = Map.of(
+            "synonym_repeated", "apple smartphone => \n  SYNONYM: iphone",
+            "synonym_nested", "iphone => \n SYNONYM: apple smartphone",
+            "synonym_weighted", "iphone => \n SYNONYM(0.5): smartphone"
+    );
+
+    private final List<Product> products = List.of(
+            product("1", "iphone", "smartphone"),
+            product("2", "apple", "smartphone"),
+            product("3", "apple smartphone", "smartphone"),
+            product("4", "apple", "case"),
+            product("5", "iphone", "case"),
+            product("6", "samsung", "case"),
+            product("7", "samsung", "smartphone")
+    );
+
+    private final QueryConfig queryConfig = QueryConfig.builder()
+            .field("name", 40.0f)
+            .field("type", 20.0f)
+            .minimumShouldMatch("100%")
+            .tie(0.0f)
+            .build();
+
+
+    private final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.create();
+
+    @Test
+    public void testThat_allProductsAreFound_forRuleThatIncludesWeightedSynonym() {
+
+        final QueryRewriting<Query> queryRewriting = queryRewriting("synonym_weighted");
+        final Query query = queryRewriting.rewriteQuery("iphone").getConvertedQuery();
+
+        final List<Product> products = search(query);
+
+        System.out.println(toIdAndScoreMaps(products));
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 40.0),
+                idAndScoreMap("2", 10.0),
+                idAndScoreMap("3", 20.0),
+                idAndScoreMap("5", 40.0),
+                idAndScoreMap("7", 10.0)
+        );
+    }
+
+    @Test
+    public void testThat_allProductsAreFound_forRuleThatLeadsToRepeatedTerm() {
+
+        final QueryRewriting<Query> queryRewriting = queryRewriting("synonym_repeated");
+        final Query query = queryRewriting.rewriteQuery("apple smartphone").getConvertedQuery();
+
+        final List<Product> products = search(query);
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 80.0),
+                idAndScoreMap("2", 60.0),
+                idAndScoreMap("3", 80.0),
+                idAndScoreMap("5", 80.0)
+        );
+    }
+
+    @Test
+    public void testThat_allProductsAreFound_forRuleThatLeadsToNestedBooleanClause() {
+
+        final QueryRewriting<Query> queryRewriting = queryRewriting("synonym_nested");
+        final Query query = queryRewriting.rewriteQuery("iphone").getConvertedQuery();
+
+        final List<Product> products = search(query);
+
+        assertThat(toIdAndScoreMaps(products)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 40.0),
+                idAndScoreMap("2", 30.0),
+                idAndScoreMap("3", 40.0),
+                idAndScoreMap("5", 40.0)
+        );
+    }
+
+    private QueryRewriting<Query> queryRewriting(final String rulesKey) {
+        return QueryRewriting.<Query>builder()
+                .queryConfig(queryConfig)
+                .querqyConfig(
+                        querqyConfig(RULES.get(rulesKey))
+                )
+                .converterFactory(converterFactory)
+                .build();
+    }
+
+    @Override
+    protected List<AbstractOpenSearchTest.Product> getProducts() {
+        return products;
+    }
+
+    @Override
+    protected String getIndexName() {
+        return INDEX_NAME;
+    }
+
+    @Override
+    protected OpenSearchContainer<?> getOpenSearchContainer() {
+        return OpenSearch2Container.createOpenSearchContainer();
+    }
+}

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -11,6 +11,7 @@ repositories {
 ext {
     querqyCoreVersion = '3.20.1'
     elasticsearchVersion = '7.17.8'
+    opensearchVersion = '3.8.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 
@@ -29,12 +30,14 @@ dependencies {
     api "org.querqy:querqy-core:${querqyCoreVersion}"
 
     compileOnly "co.elastic.clients:elasticsearch-java:${elasticsearchVersion}"
+    compileOnly "org.opensearch.client:opensearch-java:${opensearchVersion}"
 
     // Testing
     testImplementation "org.assertj:assertj-core:3.23.1"
     testImplementation "junit:junit:4.13.2"
     testImplementation "org.mockito:mockito-core:4.11.0"
     testImplementation "co.elastic.clients:elasticsearch-java:${elasticsearchVersion}"
+    testImplementation "org.opensearch.client:opensearch-java:${opensearchVersion}"
     testImplementation("org.querqy:querqy-core:${querqyCoreVersion}:tests")
 
     // Lombok

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/NumberUnitQueryCreatorOpenSearch.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/NumberUnitQueryCreatorOpenSearch.java
@@ -1,0 +1,213 @@
+package querqy.converter.opensearch.javaclient;
+
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionBoostMode;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScore;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreMode;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.RangeQuery;
+import org.opensearch.client.json.JsonData;
+import querqy.model.BoostQuery;
+import querqy.model.Clause;
+import querqy.model.RawQuery;
+import querqy.rewrite.contrib.numberunit.NumberUnitQueryCreator;
+import querqy.rewrite.contrib.numberunit.model.NumberUnitDefinition;
+import querqy.rewrite.contrib.numberunit.model.PerUnitNumberUnitDefinition;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class NumberUnitQueryCreatorOpenSearch extends NumberUnitQueryCreator {
+
+    public NumberUnitQueryCreatorOpenSearch(int scale) {
+        super(scale);
+    }
+
+
+    protected RawQuery createRawBoostQuery(final BigDecimal value,
+                                           final List<PerUnitNumberUnitDefinition> perUnitNumberUnitDefinitions) {
+
+        final List<Query> lowerFilterClauses = new ArrayList<>(perUnitNumberUnitDefinitions.size());
+        final List<Query> upperFilterClauses = new ArrayList<>(perUnitNumberUnitDefinitions.size());
+
+        final List<FunctionScore> lowerFilterFunctions = new ArrayList<>();
+        final List<Query> exactFilterFunctions = new ArrayList<>();
+        final List<FunctionScore> upperFilterFunctions = new ArrayList<>();
+
+        perUnitNumberUnitDefinitions.forEach(perUnitDef -> {
+            final NumberUnitDefinition numberUnitDef = perUnitDef.numberUnitDefinition;
+
+            final BigDecimal standardizedValue = value.multiply(perUnitDef.multiplier);
+
+            final BigDecimal lowerBound = subtractPercentage(standardizedValue,
+                    numberUnitDef.boostPercentageLowerBoundary);
+
+            final BigDecimal lowerBoundExactMatch = subtractPercentage(standardizedValue,
+                    numberUnitDef.boostPercentageLowerBoundaryExactMatch);
+
+            final BigDecimal upperBound = addPercentage(standardizedValue,
+                    numberUnitDef.boostPercentageUpperBoundary);
+
+            final BigDecimal upperBoundExactMatch = addPercentage(standardizedValue,
+                    numberUnitDef.boostPercentageUpperBoundaryExactMatch);
+
+            final BigDecimal lowerOrigin = standardizedValue.subtract(standardizedValue.subtract(lowerBoundExactMatch));
+
+            final BigDecimal lowerScale = lowerBoundExactMatch.subtract(lowerBound)
+                    .divide(BigDecimal.valueOf(2), super.getRoundingMode());
+
+            final BigDecimal lowerDecay = calculateDecay(numberUnitDef.maxScoreForExactMatch,
+                    numberUnitDef.minScoreAtLowerBoundary);
+
+            final BigDecimal upperOrigin = standardizedValue.add(upperBoundExactMatch.subtract(standardizedValue));
+
+            final BigDecimal upperScale = upperBound.subtract(upperBoundExactMatch)
+                    .divide(BigDecimal.valueOf(2), super.getRoundingMode());
+
+            final BigDecimal upperDecay = calculateDecay(numberUnitDef.maxScoreForExactMatch,
+                    numberUnitDef.minScoreAtUpperBoundary);
+
+
+
+            perUnitDef.numberUnitDefinition.fields.forEach(field -> {
+                lowerFilterClauses.add(new Query(RangeQuery.of(r -> r
+                                        .field(field.fieldName)
+                                        .gte(JsonData.of(lowerBound.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                        .lt(JsonData.of(lowerBoundExactMatch.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                ))
+                );
+                upperFilterClauses.add(
+                        new Query(RangeQuery.of(r -> r
+                                .field(field.fieldName)
+                                .gt(JsonData.of(upperBoundExactMatch.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                .lte(JsonData.of(upperBound.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                ))
+                );
+
+                lowerFilterFunctions.add(FunctionScore.of( f -> f.linear(
+                        l -> l
+                                .field(field.fieldName)
+                                .placement(p -> p
+                                        .origin(JsonData.of(lowerOrigin.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                        .scale(JsonData.of(lowerScale.doubleValue()))
+                                        .offset(JsonData.of(0))
+                                        .decay(lowerDecay.doubleValue())
+                                )
+
+
+                ).weight(numberUnitDef.maxScoreForExactMatch.floatValue())));
+
+
+                upperFilterFunctions.add( FunctionScore.of((f -> f.linear(
+                                l -> l
+                                        .field(field.fieldName)
+                                        .placement(p -> p
+                                                .origin(JsonData.of(upperOrigin.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                                .scale(JsonData.of(upperScale.doubleValue()))
+                                                .offset(JsonData.of(0))
+                                                .decay(upperDecay.doubleValue())
+                                        )
+
+
+                        ).weight(numberUnitDef.maxScoreForExactMatch.floatValue()))
+                ));
+
+                exactFilterFunctions.add( new Query(FunctionScoreQuery.of(fs -> fs
+                                .query(q -> q.range(
+                                        r -> r.field(field.fieldName)
+                                                .gte(JsonData.of(lowerBoundExactMatch.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                                .lte(JsonData.of(upperBoundExactMatch.setScale(field.scale, super.getRoundingMode()).doubleValue()))
+                                )).functions( f -> f.weight(
+                                        numberUnitDef.maxScoreForExactMatch
+                                                .add(numberUnitDef.additionalScoreForExactMatch).floatValue()
+                                        )
+
+                                )))
+                        );
+
+            });
+        });
+
+
+        final BoolQuery boolQuery = BoolQuery.of(b -> b
+                .should(
+                        new Query(FunctionScoreQuery.of(fs -> fs
+                                .query(new Query(BoolQuery.of(bq -> bq.should(lowerFilterClauses))))
+                                .functions(lowerFilterFunctions).boostMode(FunctionBoostMode.Multiply)
+                                .scoreMode(FunctionScoreMode.Max))))
+
+                .should(exactFilterFunctions)
+                .should(new Query(FunctionScoreQuery.of(fs -> fs
+                        .query(new Query(BoolQuery.of(bq -> bq.should(upperFilterClauses))))
+                        .functions(upperFilterFunctions).boostMode(FunctionBoostMode.Multiply)
+                        .scoreMode(FunctionScoreMode.Max)))
+                )
+        );
+
+
+        return new OpenSearchDSLRawQuery(null, new Query(boolQuery), Clause.Occur.MUST, true);
+    }
+
+    @Override
+    public BoostQuery createBoostQuery(final BigDecimal value,
+                                       final List<PerUnitNumberUnitDefinition> perUnitNumberUnitDefinitions) {
+        return new BoostQuery(createRawBoostQuery(value, perUnitNumberUnitDefinitions), 1.0f);
+    }
+
+    @Override
+    public RawQuery createFilterQuery(final BigDecimal value,
+                                      final List<PerUnitNumberUnitDefinition> perUnitNumberUnitDefinitions) {
+
+
+        final List<Query> queries = perUnitNumberUnitDefinitions.stream().flatMap(def -> {
+            final BigDecimal multipliedValue = value.multiply(def.multiplier);
+
+            final BigDecimal lowerBound = def.numberUnitDefinition.filterPercentageLowerBoundary.compareTo(BigDecimal.ZERO) >= 0
+                    ? subtractPercentage(multipliedValue, def.numberUnitDefinition.filterPercentageLowerBoundary)
+                    : def.numberUnitDefinition.filterPercentageLowerBoundary;
+
+            final BigDecimal upperBound = def.numberUnitDefinition.filterPercentageUpperBoundary.compareTo(BigDecimal.ZERO) >= 0
+                    ? addPercentage(multipliedValue, def.numberUnitDefinition.filterPercentageUpperBoundary)
+                    : def.numberUnitDefinition.filterPercentageUpperBoundary;
+
+            return def.numberUnitDefinition.fields.stream().map(field ->
+
+                            new Query(RangeQuery.of(
+                                    r -> {
+                                        final RangeQuery.Builder builder = r.field(field.fieldName);
+                                        if (lowerBound.compareTo(BigDecimal.ZERO) >= 0) {
+                                            builder.gte(JsonData.of(lowerBound.setScale(field.scale, super.getRoundingMode()).doubleValue()));
+                                        }
+                                        if (upperBound.compareTo(BigDecimal.ZERO) >= 0) {
+                                            builder.lte(JsonData.of(upperBound.setScale(field.scale, super.getRoundingMode()).doubleValue()));
+                                        }
+                                        return builder;
+                                    }
+
+                            ))
+
+            );
+
+        }).collect(Collectors.toUnmodifiableList());
+
+        final Query query = new Query(BoolQuery.of(
+                b -> b.minimumShouldMatch("1").
+                        should(queries)
+        ));
+
+        return new OpenSearchDSLRawQuery(null, query, Clause.Occur.SHOULD, true);
+    }
+
+    private BigDecimal calculateDecay(BigDecimal maxValue, BigDecimal minValue) {
+        final BigDecimal decayGround = minValue.divide(maxValue, super.getRoundingMode());
+        final BigDecimal decaySummand = BigDecimal.ONE.subtract(decayGround)
+                .divide(BigDecimal.valueOf(2), super.getRoundingMode());
+
+        return decayGround.add(decaySummand);
+
+    }
+
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterConfig.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterConfig.java
@@ -1,0 +1,21 @@
+package querqy.converter.opensearch.javaclient;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Builder
+@Getter
+public class OSJavaClientConverterConfig {
+
+    private static final OSJavaClientConverterConfig DEFAULT = OSJavaClientConverterConfig.builder().build();
+
+    public enum RawQueryInputType {
+        JSON, QUERY_STRING_QUERY
+    }
+
+    @Builder.Default private final RawQueryInputType rawQueryInputType = RawQueryInputType.QUERY_STRING_QUERY;
+
+    public static OSJavaClientConverterConfig defaultConfig() {
+        return DEFAULT;
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterFactory.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterFactory.java
@@ -1,0 +1,57 @@
+package querqy.converter.opensearch.javaclient;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.QueryConfig;
+import querqy.QueryExpansionConfig;
+import querqy.converter.Converter;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientBooleanQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientBoostQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientConstantScoreQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientDismaxQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientMatchAllQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientQueryStringQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientRawQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientTermQueryBuilder;
+import querqy.converter.generic.GenericConverterFactory;
+
+@RequiredArgsConstructor
+public class OSJavaClientConverterFactory implements ConverterFactory<Query> {
+
+    private final OSJavaClientConverterConfig converterConfig;
+
+    private final OSJavaClientBooleanQueryBuilder booleanQueryBuilder = OSJavaClientBooleanQueryBuilder.create();
+    private final OSJavaClientDismaxQueryBuilder dismaxQueryBuilder = OSJavaClientDismaxQueryBuilder.create();
+    private final OSJavaClientConstantScoreQueryBuilder constantScoreQueryBuilder = OSJavaClientConstantScoreQueryBuilder.create();
+    private final OSJavaClientTermQueryBuilder termQueryBuilder = OSJavaClientTermQueryBuilder.create();
+    private final OSJavaClientMatchAllQueryBuilder matchAllQueryBuilder = OSJavaClientMatchAllQueryBuilder.create();
+    private final OSJavaClientBoostQueryBuilder boostQueryBuilder = OSJavaClientBoostQueryBuilder.create();
+    private final OSJavaClientQueryStringQueryBuilder queryStringQueryBuilder = OSJavaClientQueryStringQueryBuilder.create();
+
+    @Override
+    public Converter<Query> createConverter(final QueryConfig queryConfig, final QueryExpansionConfig<Query> queryExpansionConfig) {
+        final OSJavaClientRawQueryBuilder rawQueryBuilder = OSJavaClientRawQueryBuilder.of(converterConfig);
+
+        final GenericConverterFactory<Query> converterFactory = GenericConverterFactory.<Query>builder()
+                .booleanQueryBuilder(booleanQueryBuilder)
+                .dismaxQueryBuilder(dismaxQueryBuilder)
+                .constantScoreQueryBuilder(constantScoreQueryBuilder)
+                .termQueryBuilder(termQueryBuilder)
+                .matchAllQueryBuilder(matchAllQueryBuilder)
+                .rawQueryBuilder(rawQueryBuilder)
+                .boostQueryBuilder(boostQueryBuilder)
+                .queryStringQueryBuilder(queryStringQueryBuilder)
+                .build();
+
+        return converterFactory.createConverter(queryConfig, queryExpansionConfig);
+    }
+
+    public static OSJavaClientConverterFactory create() {
+        return new OSJavaClientConverterFactory(OSJavaClientConverterConfig.defaultConfig());
+    }
+
+    public static OSJavaClientConverterFactory of(final OSJavaClientConverterConfig clientConverterConfig) {
+        return new OSJavaClientConverterFactory(clientConverterConfig);
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/OpenSearchDSLRawQuery.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/OpenSearchDSLRawQuery.java
@@ -1,0 +1,32 @@
+package querqy.converter.opensearch.javaclient;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import querqy.model.BooleanParent;
+import querqy.model.QuerqyQuery;
+import querqy.model.RawQuery;
+
+public class OpenSearchDSLRawQuery extends RawQuery {
+
+    final Query query;
+
+    public OpenSearchDSLRawQuery(final BooleanParent parent, final Query query, final Occur occur,
+                                 final boolean isGenerated) {
+        super(parent, occur, isGenerated);
+        this.query = query;
+    }
+
+    @Override
+    public QuerqyQuery<BooleanParent> clone(final BooleanParent newParent) {
+        return clone(newParent, this.generated);
+    }
+
+    @Override
+    public QuerqyQuery<BooleanParent> clone(final BooleanParent newParent, final boolean generated) {
+        return new OpenSearchDSLRawQuery(newParent, query, occur, generated);
+    }
+
+    public Query getQuery() {
+        return query;
+    }
+
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientBooleanQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientBooleanQueryBuilder.java
@@ -1,0 +1,78 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.BooleanQueryBuilder;
+import querqy.converter.generic.model.BooleanQueryDefinition;
+
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientBooleanQueryBuilder implements BooleanQueryBuilder<Query> {
+
+    private static final Query MATCH_ALL_QUERY = new Query(MatchAllQuery.of(matchAll -> matchAll));
+
+    @Override
+    public Query build(final BooleanQueryDefinition<Query> booleanQueryDefinition) {
+        return _OSJavaClientBooleanQueryBuilder.of(booleanQueryDefinition).build();
+    }
+
+    @RequiredArgsConstructor(staticName = "of")
+    private static class _OSJavaClientBooleanQueryBuilder {
+
+        private final BooleanQueryDefinition<Query> definition;
+        private final BoolQuery.Builder builder = new BoolQuery.Builder();
+
+        public Query build() {
+            addClauses();
+
+            definition.getBoost().ifPresent(builder::boost);
+            definition.getMinimumShouldMatch().ifPresent(builder::minimumShouldMatch);
+
+            return new Query(builder.build());
+        }
+
+        private void addClauses() {
+            if (definition.getMustNotClauses().size() == 1
+                    && definition.getMustClauses().isEmpty() && definition.getShouldClauses().isEmpty()) {
+                addStandaloneMustNotClause();
+
+            } else {
+                addShouldClauses();
+                addMustClauses();
+                addFilterClauses();
+                addMustNotClauses();
+            }
+        }
+
+        private void addStandaloneMustNotClause() {
+            builder.should(MATCH_ALL_QUERY);
+            addMustNotClauses();
+        }
+
+        private void addShouldClauses() {
+            for (final Query query : definition.getShouldClauses()) {
+                builder.should(query);
+            }
+        }
+
+        private void addMustClauses() {
+            for (final Query query : definition.getMustClauses()) {
+                builder.must(query);
+            }
+        }
+
+        private void addFilterClauses() {
+            for (final Query query : definition.getFilterClauses()) {
+                builder.filter(query);
+            }
+        }
+
+        private void addMustNotClauses() {
+            for (final Query query : definition.getMustNotClauses()) {
+                builder.mustNot(query);
+            }
+        }
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientBoostQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientBoostQueryBuilder.java
@@ -1,0 +1,52 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.FunctionBoostMode;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScore;
+import org.opensearch.client.opensearch._types.query_dsl.FunctionScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.BoostQueryBuilder;
+import querqy.converter.generic.model.BoostQueryDefinition;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientBoostQueryBuilder implements BoostQueryBuilder<Query> {
+
+    @Override
+    public Query createAddToBoostParamQuery(final BoostQueryDefinition<Query> boostQueryDefinition) {
+        return new Query(
+                new FunctionScoreQuery.Builder()
+                        .query(boostQueryDefinition.getQuery())
+                        .functions(createFunctionScoreByWeight(boostQueryDefinition.getBoost()))
+                        .boostMode(FunctionBoostMode.Sum)
+                        .build()
+        );
+    }
+
+    @Override
+    public Query createMultiplyWithBoostParamQuery(final BoostQueryDefinition<Query> boostQueryDefinition) {
+        return new Query(
+                new FunctionScoreQuery.Builder()
+                        .query(boostQueryDefinition.getQuery())
+                        .functions(createFunctionScoreByWeight(boostQueryDefinition.getBoost()))
+                        .boostMode(FunctionBoostMode.Multiply)
+                        .build()
+        );
+    }
+
+    @Override
+    public Query createClassicBoostQuery(BoostQueryDefinition<Query> boostQueryDefinition) {
+        throw new UnsupportedOperationException("Boost mode CLASSIC is not supported by " + this.getClass().getName());
+    }
+
+    private Query createMatchAllQuery() {
+        return new Query(new MatchAllQuery.Builder().build());
+    }
+
+    private FunctionScore createFunctionScoreByWeight(final Float weight) {
+        return new FunctionScore.Builder()
+                .filter(createMatchAllQuery())
+                .weight(weight)
+                .build();
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientConstantScoreQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientConstantScoreQueryBuilder.java
@@ -1,0 +1,21 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.ConstantScoreQueryBuilder;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientConstantScoreQueryBuilder implements ConstantScoreQueryBuilder<Query> {
+
+    @Override
+    public Query build(Query query, float constantScore) {
+        final ConstantScoreQuery.Builder constantScoreQueryBuilder = new ConstantScoreQuery.Builder();
+
+        constantScoreQueryBuilder.filter(query);
+        constantScoreQueryBuilder.boost(constantScore);
+
+        return new Query(constantScoreQueryBuilder.build());
+    }
+
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientDismaxQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientDismaxQueryBuilder.java
@@ -1,0 +1,21 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.DisMaxQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.DismaxQueryBuilder;
+import querqy.converter.generic.model.DismaxQueryDefinition;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientDismaxQueryBuilder implements DismaxQueryBuilder<Query> {
+
+    @Override
+    public Query build(final DismaxQueryDefinition<Query> dismaxQueryDefinition) {
+        final DisMaxQuery.Builder builder = new DisMaxQuery.Builder()
+                .queries(dismaxQueryDefinition.getDismaxClauses());
+
+        dismaxQueryDefinition.getTie().ifPresent(builder::tieBreaker);
+
+        return new Query(builder.build());
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientMatchAllQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientMatchAllQueryBuilder.java
@@ -1,0 +1,15 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.MatchAllQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.MatchAllQueryBuilder;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientMatchAllQueryBuilder implements MatchAllQueryBuilder<Query> {
+
+    @Override
+    public Query build() {
+        return new Query(new MatchAllQuery.Builder().build());
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientQueryStringQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientQueryStringQueryBuilder.java
@@ -1,0 +1,15 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryStringQuery;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.QueryStringQueryBuilder;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientQueryStringQueryBuilder implements QueryStringQueryBuilder<Query> {
+
+    @Override
+    public Query build(final String queryString) {
+        return new Query(new QueryStringQuery.Builder().query(queryString).build());
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientRawQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientRawQueryBuilder.java
@@ -1,0 +1,57 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import jakarta.json.stream.JsonParser;
+import lombok.RequiredArgsConstructor;
+
+import org.opensearch.client.json.JsonpMapper;
+import org.opensearch.client.json.jackson.JacksonJsonpMapper;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.client.opensearch._types.query_dsl.QueryStringQuery;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OpenSearchDSLRawQuery;
+import querqy.converter.generic.builder.RawQueryBuilder;
+import querqy.model.RawQuery;
+import querqy.model.StringRawQuery;
+
+import java.io.StringReader;
+
+@RequiredArgsConstructor(staticName = "of")
+public class OSJavaClientRawQueryBuilder implements RawQueryBuilder<Query> {
+
+    private static final JsonpMapper MAPPER = new JacksonJsonpMapper();
+
+    private final OSJavaClientConverterConfig converterConfig;
+
+    @Override
+    public Query build(final RawQuery rawQuery) {
+        if (rawQuery instanceof StringRawQuery) {
+            return buildFromStringRawQuery((StringRawQuery) rawQuery);
+        } else if (rawQuery instanceof OpenSearchDSLRawQuery) {
+            return ((OpenSearchDSLRawQuery) rawQuery).getQuery();
+        } else {
+            throw new IllegalArgumentException("Unsupported RawQuery type: " + rawQuery.getClass());
+        }
+    }
+    protected Query buildFromStringRawQuery(final StringRawQuery rawQuery) {
+        final String rawQueryString = rawQuery.getQueryString();
+        switch (converterConfig.getRawQueryInputType()) {
+
+            case QUERY_STRING_QUERY: return parseAsQueryStringQuery(rawQueryString);
+            case JSON: return parseAsJson(rawQueryString);
+
+            default:
+                throw new IllegalArgumentException(this.getClass().getName() + " does not support raw query input type " +
+                        converterConfig.getRawQueryInputType().name());
+        }
+    }
+
+    private Query parseAsQueryStringQuery(final String rawQueryString) {
+        return new Query(new QueryStringQuery.Builder().query(rawQueryString).build());
+    }
+
+    private Query parseAsJson(final String rawQueryString) {
+        try (final JsonParser parser = MAPPER.jsonProvider().createParser(new StringReader(rawQueryString))) {
+            return Query._DESERIALIZER.deserialize(parser, MAPPER);
+        }
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientTermQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientTermQueryBuilder.java
@@ -1,0 +1,26 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import org.opensearch.client.opensearch._types.FieldValue;
+import org.opensearch.client.opensearch._types.query_dsl.MatchQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import lombok.RequiredArgsConstructor;
+import querqy.converter.generic.builder.TermQueryBuilder;
+import querqy.converter.generic.model.TermQueryDefinition;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientTermQueryBuilder implements TermQueryBuilder<Query> {
+
+    @Override
+    public Query build(final TermQueryDefinition termQueryDefinition) {
+        return createTermQuery(termQueryDefinition);
+    }
+
+    private Query createTermQuery(final TermQueryDefinition termQueryDefinition) {
+        final MatchQuery.Builder termQueryBuilder = new MatchQuery.Builder();
+
+        termQueryBuilder.field(termQueryDefinition.getFieldConfig().getFieldName());
+        termQueryBuilder.query(FieldValue.of(termQueryDefinition.getTerm()));
+
+        return new Query(termQueryBuilder.build());
+    }
+}

--- a/library/src/test/java/querqy/converter/opensearch/CommonRulesRewritingTest.java
+++ b/library/src/test/java/querqy/converter/opensearch/CommonRulesRewritingTest.java
@@ -1,0 +1,228 @@
+package querqy.converter.opensearch;
+
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.junit.Test;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.domain.RewrittenQuery;
+import querqy.rewriter.builder.CommonRulesDefinition;
+
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+
+import static querqy.QuerqyMatchers.bq;
+import static querqy.QuerqyMatchers.dmq;
+import static querqy.QuerqyMatchers.term;
+
+public class CommonRulesRewritingTest {
+
+    @Test
+    public void testDecorationsWithoutKeys() {
+
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("""
+                                        iphone =>\s
+                                         SYNONYM: apple smartphone
+                                         FILTER: apple
+                                         DECORATE: REDIRECT https://example.com/apple
+
+                                        4 inch =>\s
+                                         DECORATE: TEASER <small_smartphones>""")
+                                .build()
+                )
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("name", 40.0f)
+                .field("type", 20.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+        final RewrittenQuery<Query> query = queryRewriting.rewriteQuery("iphone 4 inch ");
+
+        // test decorations
+        org.assertj.core.api.Assertions.assertThat(query.getDecorations())
+                .hasSize(2)
+                .contains("REDIRECT https://example.com/apple")
+                .contains("TEASER <small_smartphones>")
+
+        ;
+
+        // test that main query is still there
+        final Query convertedQuery = query.getConvertedQuery();
+        assertTrue(convertedQuery._get() instanceof BoolQuery);
+        final BoolQuery boolQuery = (BoolQuery) convertedQuery._get();
+        org.assertj.core.api.Assertions.assertThat(boolQuery.filter()).isNotEmpty(); // we just test whether the filter was created
+
+    }
+
+
+
+    @Test
+    public void testThatRuleFiltersAreApplied() {
+
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("""
+                                        A =>\s
+                                         SYNONYM: B
+                                         @{
+                                          "tenant": "t1"
+                                         }@
+
+                                        A =>\s
+                                         SYNONYM: C
+                                         @{
+                                          "tenant": "t2"
+                                         }@
+                                        """
+                                )
+                                .build()
+                )
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("name", 40.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+
+        // test all synonyms are applied when there is no filter
+        final RewrittenQuery<Query> query = queryRewriting.rewriteQuery("A");
+
+        assertThat((querqy.model.Query) query.getRewrittenQuerqyQuery().getQuery().getUserQuery(),
+        bq(
+                dmq(
+                        term("A", false),
+                        term("B", true),
+                        term("C", true)
+                )
+        ));
+
+
+        final QueryConfig queryConfigWithFilter = QueryConfig.builder()
+                .field("name", 40.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .addRewriterParam("id1", "criteria.filter", "$[?(@.tenant == 't1')]" )
+                .build();
+
+        final QueryRewriting<Query> queryRewritingWithFilter = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfigWithFilter)
+                .converterFactory(converterFactory)
+                .build();
+
+
+
+        // now add the filter for tenant t1
+        final RewrittenQuery<Query> queryWithAppliedFilter = queryRewritingWithFilter.rewriteQuery("A");
+        assertThat((querqy.model.Query) queryWithAppliedFilter.getRewrittenQuerqyQuery().getQuery().getUserQuery(),
+                bq(
+                        dmq(
+                                term("A", false),
+                                term("B", true)
+                        )
+                ));
+
+    }
+
+    @Test
+    public void testThatRuleOrderingAndLimitsAreApplied() {
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("""
+                                        A =>\s
+                                         SYNONYM: B
+                                         @{
+                                          "prio": 2
+                                         }@
+
+                                        A =>\s
+                                         SYNONYM: C
+                                         @{
+                                          "prio": 1
+                                         }@
+                                         """
+                                )
+                                .build()
+                )
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("name", 40.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .addRewriterParam("id1", "criteria.sort", "prio asc")
+                .addRewriterParam("id1", "criteria.limit", 1)
+                .addRewriterParam("id1", "criteria.limitByLevel", true)
+
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+        final RewrittenQuery<Query> queryWithAppliedOrder = queryRewriting.rewriteQuery("A");
+
+        assertThat((querqy.model.Query) queryWithAppliedOrder.getRewrittenQuerqyQuery().getQuery().getUserQuery(),
+                bq(
+                        dmq(
+                                term("A", false),
+                                term("C", true)
+                        )
+                ));
+
+    }
+
+
+}

--- a/library/src/test/java/querqy/converter/opensearch/NumberUnitRewritingTest.java
+++ b/library/src/test/java/querqy/converter/opensearch/NumberUnitRewritingTest.java
@@ -1,0 +1,99 @@
+package querqy.converter.opensearch;
+
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+
+import org.junit.Test;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.converter.opensearch.javaclient.NumberUnitQueryCreatorOpenSearch;
+import querqy.domain.RewrittenQuery;
+import querqy.rewriter.builder.CommonRulesDefinition;
+import querqy.rewriter.builder.NumberUnitRulesDefinition;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+
+public class NumberUnitRewritingTest {
+
+    private static final int DEFAULT_SCALE_FOR_LINEAR_FUNCTIONS = 5;
+
+    static final String NUMBER_UNIT_CONFIG = "{\n" +
+            "   \"numberUnitDefinitions\": [\n" +
+            "       {\n" +
+            "          \"units\": [ { \"term\": \"inch\" } ],\n" +
+            "          \"fields\": [ { \"fieldName\": \"screen_size\" , \"scale\":1 } ],\n" +
+            "          \"boost\": {\n" +
+            "             \"percentageLowerBoundary\": 10,\n" +
+            "             \"percentageUpperBoundary\": 10,\n" +
+            " \n" +
+            "            \"minScoreAtLowerBoundary\": 20,\n" +
+            "            \"minScoreAtUpperBoundary\": 20,\n" +
+            "\n" +
+            "            \"percentageLowerBoundaryExactMatch\": 5,\n" +
+            "            \"percentageUpperBoundaryExactMatch\": 5,\n" +
+            "\n" +
+            "            \"maxScoreForExactMatch\": 40,\n" +
+            "            \"additionalScoreForExactMatch\": 15\n" +
+            "         },\n" +
+            "         \"filter\": {\n" +
+            "            \"percentageLowerBoundary\": 20,\n" +
+            "            \"percentageUpperBoundary\": 10\n" +
+            "         }\n" +
+            "      }\n" +
+            "   ]\n" +
+            "}";
+
+
+    @Test
+    public void testRewriting()  {
+
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+
+                .commonRules(
+                        CommonRulesDefinition.builder()
+                                .rewriterId("id1")
+                                .rules("iphone => \n SYNONYM: apple smartphone\n\niphone =>\n" +
+                                        "DOWN(5): * {\"term\":{\"category\": \"accessories\"}}")
+                                .build()
+                )
+                .numberUnitRules(NumberUnitRulesDefinition.builder()
+                        .rewriterId("id2")
+                        .rules(NUMBER_UNIT_CONFIG)
+                        .numberUnitQueryCreator(new NumberUnitQueryCreatorOpenSearch(DEFAULT_SCALE_FOR_LINEAR_FUNCTIONS))
+                        .build())
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("name", 40.0f)
+                .field("type", 20.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+        final RewrittenQuery<Query> query = queryRewriting.rewriteQuery("iphone 4 inch ");
+        final Query convertedQuery = query.getConvertedQuery();
+        assertTrue(convertedQuery._get() instanceof BoolQuery);
+        final BoolQuery boolQuery = (BoolQuery) convertedQuery._get();
+        assertThat(boolQuery.filter()).isNotEmpty(); // we just test whether the filter was created
+    }
+
+
+}

--- a/library/src/test/java/querqy/converter/opensearch/RegexReplaceRewritingTest.java
+++ b/library/src/test/java/querqy/converter/opensearch/RegexReplaceRewritingTest.java
@@ -1,0 +1,102 @@
+package querqy.converter.opensearch;
+
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.junit.Assert;
+import org.junit.Test;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.domain.RewrittenQuery;
+import querqy.model.QuerqyQuery;
+import querqy.rewriter.builder.CommonRulesDefinition;
+import querqy.rewriter.builder.RegexReplaceRulesDefinition;
+
+import java.util.Collection;
+
+import static org.junit.Assert.assertEquals;
+
+import static querqy.QuerqyMatchers.bq;
+import static querqy.QuerqyMatchers.dmq;
+import static querqy.QuerqyMatchers.must;
+import static querqy.QuerqyMatchers.term;
+
+public class RegexReplaceRewritingTest {
+
+
+    @Test
+    public void testThat_RegexRewriterIsAppliedInChain() {
+
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+            final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+                    .regexReplaceRules(
+                            RegexReplaceRulesDefinition.builder()
+                                    .rewriterId("id1")
+                                    .rules("""
+                                            iphone (\\d+) gb => apple smartphone ${1}gb
+                                            (\\d+) ?x ?(\\d+) => ${1}x${2}
+                                            """)
+                                    .build()
+                    )
+
+                    .commonRules(
+                            CommonRulesDefinition.builder()
+                                    .rewriterId("id2")
+                                    .rules("""
+                                        apple =>\s
+                                         FILTER: testcategory
+                                        """
+                                    )
+                                    .build()
+                    )
+                    .build();
+
+            final QueryConfig queryConfig = QueryConfig.builder()
+                    .field("name", 40.0f)
+                    .minimumShouldMatch("100%")
+                    .tie(0.0f)
+                    .build();
+
+            final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                    .querqyConfig(querqyConfig)
+                    .queryConfig(queryConfig)
+                    .converterFactory(converterFactory)
+                    .build();
+
+            final RewrittenQuery<Query> rewrittenQuery = queryRewriting.rewriteQuery("iphone 128 gb");
+
+            Assert.assertThat((querqy.model.Query) rewrittenQuery.getRewrittenQuerqyQuery().getQuery().getUserQuery(),
+                    bq(
+                            dmq(
+                                    term("apple", false)
+                            ),
+                            dmq(
+                                    term("smartphone", false)
+                                    ),
+                            dmq(
+                                    term("128gb", false)
+                                    )
+                    ));
+
+        final Collection<QuerqyQuery<?>> filterQueries = rewrittenQuery.getRewrittenQuerqyQuery().getQuery()
+                .getFilterQueries();
+
+        assertEquals(1, filterQueries.size());
+
+
+        Assert.assertThat((querqy.model.Query) filterQueries.iterator().next(),
+                bq(
+                        dmq(
+                            must(), term("testcategory", true)
+                        )
+                ));
+
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,5 +1,6 @@
 rootProject.name = 'querqy-unplugged'
 include 'integration-elasticsearch'
+include 'integration-opensearch'
 include 'integration-solr'
 include 'library'
 


### PR DESCRIPTION
Add an OpenSearch integration mirroring the existing Elasticsearch one, using the opensearch-java 3.8.0 client.

- library: new querqy.converter.opensearch.javaclient package (converter factory, config, DSL raw query, NumberUnit query creator and the 8 query builders) implementing the existing generic builder interfaces and producing org.opensearch.client.opensearch._types.query_dsl.Query objects
- library: add opensearch-java as compileOnly/testImplementation; both ES and OpenSearch clients coexist on the classpath
- library: mirror the ES unit tests for the OpenSearch converter
- integration-opensearch: new module with a Testcontainers-based OpenSearch setup and ported rewriting/expansion integration tests

Adapts for opensearch-java 3.x API differences vs elasticsearch-java 7.17: wrap variants via new Query(...) instead of _toQuery(), parse JSON raw queries via Query._DESERIALIZER, Float weights/tieBreaker, and FieldValue for match/term values.