### PR TITLE
Make PhraseBoostRewriter available for OpenSearch. Closes #23

### DIFF
--- a/integration-opensearch/src/test/java/opensearch/rewriting/PhraseBoostTest.java
+++ b/integration-opensearch/src/test/java/opensearch/rewriting/PhraseBoostTest.java
@@ -1,0 +1,123 @@
+package opensearch.rewriting;
+
+import opensearch.AbstractOpenSearchTest;
+import opensearch.OpenSearch2Container;
+import org.junit.Test;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import org.opensearch.testcontainers.OpenSearchContainer;
+import querqy.BoostConfig;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.rewriter.builder.FieldBoost;
+import querqy.rewriter.builder.PhraseBoostDefinition;
+import querqy.rewriter.builder.PhraseConfig;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PhraseBoostTest extends AbstractOpenSearchTest {
+
+    private static final String INDEX_NAME = "phrase-boost-products";
+
+    // All docs contain both query terms so they all match with minimumShouldMatch=100%.
+    // Doc 1: adjacent phrase → matches slop=0 and slop=1.
+    // Doc 2, 3: one word between the terms (distance=1) → match only slop=1, not slop=0.
+    private final List<Product> products = List.of(
+            product("1", "apple smartphone", "device"),
+            product("2", "apple great smartphone", "device"),
+            product("3", "apple new smartphone", "device")
+    );
+
+    private final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.create();
+
+    @Test
+    public void testThat_exactPhraseMatchScoresHigher_thanNonAdjacentTerms() {
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .queryConfig(QueryConfig.builder()
+                        .field("name", 40.0f)
+                        .minimumShouldMatch("100%")
+                        .tie(0.0f)
+                        .boostConfig(BoostConfig.builder()
+                                .queryScoreConfig(BoostConfig.QueryScoreConfig.IGNORE_QUERY_SCORE)
+                                .build())
+                        .build())
+                .querqyConfig(QuerqyConfig.builder()
+                        .phraseBoost(PhraseBoostDefinition.builder()
+                                .rewriterId("phrase-boost")
+                                .bigram(PhraseConfig.builder()
+                                        .field(FieldBoost.builder().field("name").boost(100.0f).build())
+                                        .slop(0)
+                                        .build())
+                                .build())
+                        .build())
+                .converterFactory(converterFactory)
+                .build();
+
+        final Query query = queryRewriting.rewriteQuery("apple smartphone").getConvertedQuery();
+
+        final List<Product> results = search(query);
+
+        // doc 1 scores 81.0: base (40+40) + phrase boost (1.0, constantScore)
+        // docs 2 and 3 score 80.0: base only, no adjacent phrase match at slop=0
+        assertThat(toIdAndScoreMaps(results)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 81.0),
+                idAndScoreMap("2", 80.0),
+                idAndScoreMap("3", 80.0)
+        );
+    }
+
+    @Test
+    public void testThat_slopAllowsNearbyPhraseToScore() {
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .queryConfig(QueryConfig.builder()
+                        .field("name", 40.0f)
+                        .minimumShouldMatch("100%")
+                        .tie(0.0f)
+                        .boostConfig(BoostConfig.builder()
+                                .queryScoreConfig(BoostConfig.QueryScoreConfig.IGNORE_QUERY_SCORE)
+                                .build())
+                        .build())
+                .querqyConfig(QuerqyConfig.builder()
+                        .phraseBoost(PhraseBoostDefinition.builder()
+                                .rewriterId("phrase-boost")
+                                .bigram(PhraseConfig.builder()
+                                        .field(FieldBoost.builder().field("name").boost(100.0f).build())
+                                        .slop(1)
+                                        .build())
+                                .build())
+                        .build())
+                .converterFactory(converterFactory)
+                .build();
+
+        final Query query = queryRewriting.rewriteQuery("apple smartphone").getConvertedQuery();
+
+        final List<Product> results = search(query);
+
+        // All docs match "apple smartphone" with slop=1 (each has at most 1 word between the terms),
+        // so all three receive the phrase boost → 80.0 base + 1.0 constantScore boost = 81.0
+        assertThat(toIdAndScoreMaps(results)).containsExactlyInAnyOrder(
+                idAndScoreMap("1", 81.0),
+                idAndScoreMap("2", 81.0),
+                idAndScoreMap("3", 81.0)
+        );
+    }
+
+    @Override
+    protected List<Product> getProducts() {
+        return products;
+    }
+
+    @Override
+    protected String getIndexName() {
+        return INDEX_NAME;
+    }
+
+    @Override
+    protected OpenSearchContainer<?> getOpenSearchContainer() {
+        return OpenSearch2Container.createOpenSearchContainer();
+    }
+}

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterFactory.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/OSJavaClientConverterFactory.java
@@ -12,6 +12,7 @@ import querqy.converter.opensearch.javaclient.builder.OSJavaClientConstantScoreQ
 import querqy.converter.opensearch.javaclient.builder.OSJavaClientDismaxQueryBuilder;
 import querqy.converter.opensearch.javaclient.builder.OSJavaClientMatchAllQueryBuilder;
 import querqy.converter.opensearch.javaclient.builder.OSJavaClientQueryStringQueryBuilder;
+import querqy.converter.opensearch.javaclient.builder.OSJavaClientPhraseQueryBuilder;
 import querqy.converter.opensearch.javaclient.builder.OSJavaClientRawQueryBuilder;
 import querqy.converter.opensearch.javaclient.builder.OSJavaClientTermQueryBuilder;
 import querqy.converter.generic.GenericConverterFactory;
@@ -28,6 +29,7 @@ public class OSJavaClientConverterFactory implements ConverterFactory<Query> {
     private final OSJavaClientMatchAllQueryBuilder matchAllQueryBuilder = OSJavaClientMatchAllQueryBuilder.create();
     private final OSJavaClientBoostQueryBuilder boostQueryBuilder = OSJavaClientBoostQueryBuilder.create();
     private final OSJavaClientQueryStringQueryBuilder queryStringQueryBuilder = OSJavaClientQueryStringQueryBuilder.create();
+    private final OSJavaClientPhraseQueryBuilder phraseQueryBuilder = OSJavaClientPhraseQueryBuilder.create();
 
     @Override
     public Converter<Query> createConverter(final QueryConfig queryConfig, final QueryExpansionConfig<Query> queryExpansionConfig) {
@@ -42,6 +44,7 @@ public class OSJavaClientConverterFactory implements ConverterFactory<Query> {
                 .rawQueryBuilder(rawQueryBuilder)
                 .boostQueryBuilder(boostQueryBuilder)
                 .queryStringQueryBuilder(queryStringQueryBuilder)
+                .phraseQueryBuilder(phraseQueryBuilder)
                 .build();
 
         return converterFactory.createConverter(queryConfig, queryExpansionConfig);

--- a/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientPhraseQueryBuilder.java
+++ b/library/src/main/java/querqy/converter/opensearch/javaclient/builder/OSJavaClientPhraseQueryBuilder.java
@@ -1,0 +1,26 @@
+package querqy.converter.opensearch.javaclient.builder;
+
+import lombok.RequiredArgsConstructor;
+import org.opensearch.client.opensearch._types.query_dsl.MatchPhraseQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import querqy.converter.generic.builder.PhraseQueryBuilder;
+
+import java.util.List;
+
+@RequiredArgsConstructor(staticName = "create")
+public class OSJavaClientPhraseQueryBuilder implements PhraseQueryBuilder<Query> {
+
+    @Override
+    public Query build(final String field, final List<String> terms, final int slop, final float boost) {
+        final MatchPhraseQuery.Builder builder = new MatchPhraseQuery.Builder()
+                .field(field)
+                .query(String.join(" ", terms))
+                .boost(boost);
+
+        if (slop > 0) {
+            builder.slop(slop);
+        }
+
+        return new Query(builder.build());
+    }
+}

--- a/library/src/test/java/querqy/converter/opensearch/PhraseBoostRewritingTest.java
+++ b/library/src/test/java/querqy/converter/opensearch/PhraseBoostRewritingTest.java
@@ -1,0 +1,104 @@
+package querqy.converter.opensearch;
+
+import org.junit.Test;
+import org.opensearch.client.opensearch._types.query_dsl.BoolQuery;
+import org.opensearch.client.opensearch._types.query_dsl.ConstantScoreQuery;
+import org.opensearch.client.opensearch._types.query_dsl.DisMaxQuery;
+import org.opensearch.client.opensearch._types.query_dsl.MatchPhraseQuery;
+import org.opensearch.client.opensearch._types.query_dsl.Query;
+import querqy.QuerqyConfig;
+import querqy.QueryConfig;
+import querqy.QueryRewriting;
+import querqy.converter.ConverterFactory;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterConfig;
+import querqy.converter.opensearch.javaclient.OSJavaClientConverterFactory;
+import querqy.domain.RewrittenQuery;
+import querqy.rewriter.builder.FieldBoost;
+import querqy.rewriter.builder.PhraseBoostDefinition;
+import querqy.rewriter.builder.PhraseConfig;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.assertTrue;
+
+public class PhraseBoostRewritingTest {
+
+    @Test
+    public void testPhraseBoostQueryIsAddedAsShould() {
+
+        final ConverterFactory<Query> converterFactory = OSJavaClientConverterFactory.of(
+                OSJavaClientConverterConfig.builder()
+                        .rawQueryInputType(OSJavaClientConverterConfig.RawQueryInputType.JSON)
+                        .build()
+        );
+
+        final QuerqyConfig querqyConfig = QuerqyConfig.builder()
+                .phraseBoost(PhraseBoostDefinition.builder()
+                        .rewriterId("phrase-boost")
+                        .bigram(PhraseConfig.builder()
+                                .field(FieldBoost.builder().field("title").boost(1.5f).build())
+                                .slop(0)
+                                .build())
+                        .full(PhraseConfig.builder()
+                                .field(FieldBoost.builder().field("title").boost(1.0f).build())
+                                .slop(1)
+                                .build())
+                        .tieBreaker(0.0f)
+                        .build())
+                .build();
+
+        final QueryConfig queryConfig = QueryConfig.builder()
+                .field("title", 1.0f)
+                .minimumShouldMatch("100%")
+                .tie(0.0f)
+                .build();
+
+        final QueryRewriting<Query> queryRewriting = QueryRewriting.<Query>builder()
+                .querqyConfig(querqyConfig)
+                .queryConfig(queryConfig)
+                .converterFactory(converterFactory)
+                .build();
+
+        // two-term query: bigram "apple iphone" + full phrase "apple iphone" boosts are generated
+        final RewrittenQuery<Query> result = queryRewriting.rewriteQuery("apple iphone");
+        final Query convertedQuery = result.getConvertedQuery();
+
+        // outer query is a bool with must=userQuery and should=phraseBoosts
+        assertTrue(convertedQuery._get() instanceof BoolQuery);
+        final BoolQuery outerBool = (BoolQuery) convertedQuery._get();
+        assertThat(outerBool.should()).isNotEmpty();
+
+        // the phrase boost is wrapped in a constant_score (IGNORE_QUERY_SCORE mode)
+        final Query shouldClause = outerBool.should().get(0);
+        assertTrue(shouldClause._get() instanceof ConstantScoreQuery);
+        final ConstantScoreQuery constantScore = (ConstantScoreQuery) shouldClause._get();
+
+        // inside the constant_score: a bool wrapping a dis_max of phrase queries
+        final Query filterQuery = constantScore.filter();
+        assertTrue(filterQuery._get() instanceof BoolQuery);
+        final BoolQuery phraseBool = (BoolQuery) filterQuery._get();
+        assertThat(phraseBool.should()).hasSize(1);
+
+        final Query dmqClause = phraseBool.should().get(0);
+        assertTrue(dmqClause._get() instanceof DisMaxQuery);
+        final DisMaxQuery disMaxQuery = (DisMaxQuery) dmqClause._get();
+
+        // bigram "apple iphone" on title^1.5  +  full "apple iphone" on title^1.0
+        assertThat(disMaxQuery.queries()).hasSize(2);
+
+        final Query bigramQuery = disMaxQuery.queries().get(0);
+        assertTrue(bigramQuery._get() instanceof MatchPhraseQuery);
+        final MatchPhraseQuery bigramPhrase = (MatchPhraseQuery) bigramQuery._get();
+        assertThat(bigramPhrase.field()).isEqualTo("title");
+        assertThat(bigramPhrase.query()).isEqualTo("apple iphone");
+        assertThat(bigramPhrase.boost()).isEqualTo(1.5f);
+        assertThat(bigramPhrase.slop()).isNull(); // slop=0 means not set
+
+        final Query fullPhraseQuery = disMaxQuery.queries().get(1);
+        assertTrue(fullPhraseQuery._get() instanceof MatchPhraseQuery);
+        final MatchPhraseQuery fullPhrase = (MatchPhraseQuery) fullPhraseQuery._get();
+        assertThat(fullPhrase.field()).isEqualTo("title");
+        assertThat(fullPhrase.query()).isEqualTo("apple iphone");
+        assertThat(fullPhrase.boost()).isEqualTo(1.0f);
+        assertThat(fullPhrase.slop()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Add OSJavaClientPhraseQueryBuilder converting PhraseQuery to match_phrase queries via the OpenSearch Java client, wire it into OSJavaClientConverterFactory, and add a unit test verifying the query structure and a Docker-based integration test confirming that exact-phrase matches score higher at slop=0, and that slop=1 also boosts near-phrase documents.